### PR TITLE
Solves crash on ATI cards

### DIFF
--- a/OrionUO/Gumps/Gump.cpp
+++ b/OrionUO/Gumps/Gump.cpp
@@ -1172,8 +1172,8 @@ void CGump::GenerateFrame(bool stop)
 
 	//Remove use of display list fix ATI crash - DarkLotus
 	//glNewList((GLuint)this, GL_COMPILE);
-
-	DrawItems((CBaseGUI*)m_Items, m_Page, m_Draw2Page);
+	//Fixes gump being drawn at 0,0 as well as current location on a redraw.
+	//DrawItems((CBaseGUI*)m_Items, m_Page, m_Draw2Page);
 
 	//if (stop)
 	//	glEndList();

--- a/OrionUO/Gumps/Gump.cpp
+++ b/OrionUO/Gumps/Gump.cpp
@@ -1170,12 +1170,13 @@ void CGump::GenerateFrame(bool stop)
 
 	CalculateGumpState();
 
-	glNewList((GLuint)this, GL_COMPILE);
+	//Remove use of display list fix ATI crash - DarkLotus
+	//glNewList((GLuint)this, GL_COMPILE);
 
-		DrawItems((CBaseGUI*)m_Items, m_Page, m_Draw2Page);
+	DrawItems((CBaseGUI*)m_Items, m_Page, m_Draw2Page);
 
-	if (stop)
-		glEndList();
+	//if (stop)
+	//	glEndList();
 
 	m_WantRedraw = true;
 	m_FrameCreated = true;
@@ -1202,7 +1203,8 @@ void CGump::Draw()
 
 	glTranslatef(g_GumpTranslate.X, g_GumpTranslate.Y, 0.0f);
 
-	glCallList((GLuint)this);
+	DrawItems((CBaseGUI*)m_Items, m_Page, m_Draw2Page);
+	//glCallList((GLuint)this);
 
 	g_GL.OldTexture = 0;
 


### PR DESCRIPTION
Appears to solve the ATI issues, no crashes on my HD6950 now.
Seems like ATI drivers do not like glCallList etc