### PR TITLE
Add a simpler way to configure OrionUO

### DIFF
--- a/OrionUO/EnumList.h
+++ b/OrionUO/EnumList.h
@@ -89,37 +89,38 @@ enum ENCRYPTION_TYPE
 	ET_TFISH		//!TwoFish + MD5
 };
 //----------------------------------------------------------------------------------
-//!Версия клиента (для изменения в протоколе и прочих няшках)
+#define CLIENT_VERSION(a, b, c, d) ((a << 24) | (b << 16) | (c << 8) | (d))
+//! Client Protocol Version
 enum CLIENT_VERSION
 {
-	CV_OLD = 0,		//Предшествующие клиенту 2.0.0, Остальные по логике, исходя из названия
-	CV_200,			//Отправляется пакет с габаритами экрана
-	//CV_204C,		//Использование *.def файлов
-	CV_305D,		//Использование клилоков, количество слотов в списке персонажей равно количеству персонажей
-	CV_306E,		//Добавлен пакет с типом клиента (0xBF subcmd 0x0F), использование mp3 вместо midi
-	CV_308D,		//Добавлен параметр Maximum Stats в статусбар
-	CV_308J,		//Добавлен параметр Followers в статусбар
-	CV_308Z,		//Добавлены классы paladin, necromancer; custom houses, 5 resistances, изменено окно выбора профессии, убрана галочка Save Password
-	CV_400B,		//Удаление тултипов
-	CV_405A,		//Добавлены классы ninja, samurai
-	CV_4011D,		//Изменение окна создания персонажа. Добавлена расса elves
-	CV_500A,		//Кнопки папердолла заменены: Journal -> Quests; Chat -> Guild, использование Mega Cliloc, Убрана загрузка файла Verdata.mul
-	CV_5020,		//Добавлен гамп бафов
-	CV_5090,		//
-	CV_6000,		//Добавлены цвета гильд/алли чата, игноры чатов. Добавлены опции новой таргет системы, вывод свойств предметов, Object Handles,
-	CV_6013,		//
-	CV_6017,		//
-	CV_6040,		//Увеличилось количество слотов персонажей
-	CV_6060,		//
-	CV_60142,		//
-	CV_60144,		//Изменение окна создания персонажа. Добавлена расса gargoyle
-	CV_7000,		//
-	CV_7090,		//
-	CV_70130,		//
-	CV_70160,		//
-	CV_70180,		//
-	CV_70240,		//*.mul -> *.uop
-	CV_70331		//
+	CV_OLD = CLIENT_VERSION(1, 0, 0, 0),		// Original game
+	CV_200 = CLIENT_VERSION(2, 0, 0, 0),		// T2A Introduction. Adds screen dimensions packet
+	CV_204C = CLIENT_VERSION(2, 0, 4, 2),		// Adds *.def files
+	CV_305D = CLIENT_VERSION(3, 0, 5, 3),		// Renaissance. Expanded character slots.
+	CV_306E = CLIENT_VERSION(3, 0, 6, 4),		// Adds a packet with the client type, switches to mp3 from midi for sound files
+	CV_308D = CLIENT_VERSION(3, 0, 8, 3),		// Adds maximum stats to the status bar
+	CV_308J = CLIENT_VERSION(3, 0, 8, 9),		// Adds followers to the status bar
+	CV_308Z = CLIENT_VERSION(3, 0, 8, 25),		// Age of Shadows. Adds paladin, necromancer, custom housing, resists, profession selection window, removes save password checkbox
+	CV_400B = CLIENT_VERSION(4, 0, 0, 1),		// Deletes tooltips
+	CV_405A = CLIENT_VERSION(4, 0, 5, 0),		// Adds ninja, samurai
+	CV_4011D = CLIENT_VERSION(4, 0, 11, 3),		// Adds elven race
+	CV_500A = CLIENT_VERSION(5, 0, 0, 0),		// Paperdoll buttons journal becomes quests, chat becomes guild. Use mega cliloc. Removes verdata.mul.
+	CV_5020 = CLIENT_VERSION(5, 0, 2, 0),		// Adds buff bar
+	CV_5090 = CLIENT_VERSION(5, 0, 9, 0),		//
+	CV_6000 = CLIENT_VERSION(6, 0, 0, 0),		// Adds colored guild/all chat and ignore system. New targeting systems, object properties and handles.
+	CV_6013 = CLIENT_VERSION(6, 0, 1, 3),		//
+	CV_6017 = CLIENT_VERSION(6, 0, 1, 7),		//
+	CV_6040 = CLIENT_VERSION(6, 0, 4, 0),		// Increased number of player slots
+	CV_6060 = CLIENT_VERSION(6, 0, 6, 0),		//
+	CV_60142 = CLIENT_VERSION(6, 0, 14, 2),		//
+	CV_60144 = CLIENT_VERSION(6, 0, 14, 4),		// Adds gargoyle race.
+	CV_7000 = CLIENT_VERSION(7, 0, 0, 0),		//
+	CV_7090 = CLIENT_VERSION(7, 0, 9, 0),		//
+	CV_70130 = CLIENT_VERSION(7, 0, 13, 0),		//
+	CV_70160 = CLIENT_VERSION(7, 0, 16, 0),		//
+	CV_70180 = CLIENT_VERSION(7, 0, 18, 0),		//
+	CV_70240 = CLIENT_VERSION(7, 0, 24, 0),		// *.mul -> *.uop
+	CV_70331 = CLIENT_VERSION(7, 0, 33, 1)		//
 };
 //----------------------------------------------------------------------------------
 //!На какой стадии находится окно коннекта

--- a/OrionUO/Globals.cpp
+++ b/OrionUO/Globals.cpp
@@ -45,8 +45,28 @@ GAME_STATE g_GameState = GS_MAIN;
 
 CGLTexture g_TextureGumpState[2];
 
-WISP_GEOMETRY::CSize g_MapSize[MAX_MAPS_COUNT];
-WISP_GEOMETRY::CSize g_MapBlockSize[MAX_MAPS_COUNT];
+/* The map files are linear lists of blocks, which are 8x8
+ * sets of tiles. You have to just "know" the x/y dimensions
+ * to correctly interpret them. Initialize the values
+ * to the correct sizes for 4.x+ clients.
+ */
+WISP_GEOMETRY::CSize g_MapSize[MAX_MAPS_COUNT] = {
+	{ 7168, 4096 },
+	{ 7168, 4096 },
+	{ 2304, 1600 },
+	{ 2560, 2048 },
+	{ 1448, 1448 },
+	{ 1280, 4096 },
+};
+WISP_GEOMETRY::CSize g_MapBlockSize[MAX_MAPS_COUNT] = {
+	{ 896, 512 },
+	{ 896, 512 },
+	{ 288, 200 },
+	{ 320, 256 },
+	{ 181, 181 },
+	{ 160, 512 },
+};
+
 
 int g_MultiIndexCount = 0;
 

--- a/OrionUO/Managers/AnimationManager.cpp
+++ b/OrionUO/Managers/AnimationManager.cpp
@@ -462,7 +462,7 @@ void CAnimationManager::InitIndexReplaces(puint verdata)
 	{
 		static const string typeNames[5] = { "animal", "monster", "sea_monster", "human", "equipment" };
 
-		WISP_FILE::CTextFileParser mobtypesParser(g_App.FilePath("mobtypes.txt").c_str(), " \t", "#;//", "");
+		WISP_FILE::CTextFileParser mobtypesParser(g_Orion.ClientFilePath("mobtypes.txt").c_str(), " \t", "#;//", "");
 
 		while (!mobtypesParser.IsEOF())
 		{
@@ -487,19 +487,19 @@ void CAnimationManager::InitIndexReplaces(puint verdata)
 	}
 
 	WISP_FILE::CTextFileParser newBodyParser("", " \t,{}", "#;//", "");
-	WISP_FILE::CTextFileParser bodyParser(g_App.FilePath("Body.def").c_str(), " \t", "#;//", "{}");
-	WISP_FILE::CTextFileParser bodyconvParser(g_App.FilePath("Bodyconv.def").c_str(), " \t", "#;//", "");
-	WISP_FILE::CTextFileParser corpseParser(g_App.FilePath("Corpse.def").c_str(), " \t", "#;//", "{}");
+	WISP_FILE::CTextFileParser bodyParser(g_Orion.ClientFilePath("Body.def").c_str(), " \t", "#;//", "{}");
+	WISP_FILE::CTextFileParser bodyconvParser(g_Orion.ClientFilePath("Bodyconv.def").c_str(), " \t", "#;//", "");
+	WISP_FILE::CTextFileParser corpseParser(g_Orion.ClientFilePath("Corpse.def").c_str(), " \t", "#;//", "{}");
 
 	/*WISP_FILE::CTextFileParser animParser[4]
 	{
-		WISP_FILE::CTextFileParser(g_App.FilePath("Anim1.def").c_str(), " \t", "#;//", "{}"),
-		WISP_FILE::CTextFileParser(g_App.FilePath("Anim2.def").c_str(), " \t", "#;//", "{}"),
-		WISP_FILE::CTextFileParser(g_App.FilePath("Anim3.def").c_str(), " \t", "#;//", "{}"),
-		WISP_FILE::CTextFileParser(g_App.FilePath("Anim4.def").c_str(), " \t", "#;//", "{}")
+		WISP_FILE::CTextFileParser(g_Orion.ClientFilePath("Anim1.def").c_str(), " \t", "#;//", "{}"),
+		WISP_FILE::CTextFileParser(g_Orion.ClientFilePath("Anim2.def").c_str(), " \t", "#;//", "{}"),
+		WISP_FILE::CTextFileParser(g_Orion.ClientFilePath("Anim3.def").c_str(), " \t", "#;//", "{}"),
+		WISP_FILE::CTextFileParser(g_Orion.ClientFilePath("Anim4.def").c_str(), " \t", "#;//", "{}")
 	};*/
 
-	WISP_FILE::CTextFileParser equipConvParser(g_App.FilePath("EquipConv.def"), " \t", "#;//", "");
+	WISP_FILE::CTextFileParser equipConvParser(g_Orion.ClientFilePath("EquipConv.def"), " \t", "#;//", "");
 
 	while (!equipConvParser.IsEOF())
 	{

--- a/OrionUO/Managers/CityManager.cpp
+++ b/OrionUO/Managers/CityManager.cpp
@@ -33,7 +33,7 @@ void CCityManager::Init()
 	WISPFUN_DEBUG("c134_f1");
 	WISP_FILE::CMappedFile file;
 
-	if (file.Load(g_App.FilePath("citytext.enu")))
+	if (file.Load(g_Orion.ClientFilePath("citytext.enu")))
 	{
 		puchar end = file.Ptr + file.Size;
 

--- a/OrionUO/Managers/ClilocManager.cpp
+++ b/OrionUO/Managers/ClilocManager.cpp
@@ -22,7 +22,7 @@ CCliloc::CCliloc(const string &lang)
 
 	if (m_Language.length())
 	{
-		string path = g_App.FilePath((string("cliloc.") + lang).c_str());
+		string path = g_Orion.ClientFilePath((string("cliloc.") + lang).c_str());
 
 		if (m_File.Load(path))
 			m_Loaded = true;

--- a/OrionUO/Managers/ConnectionManager.cpp
+++ b/OrionUO/Managers/ConnectionManager.cpp
@@ -100,7 +100,11 @@ void CConnectionManager::Init()
 			UCHAR_LIST &data = stream.Data();
 
 			memcpy(&m_Seed[0], &data[0], 4);
-			g_NetworkInit(true, &data[0]);
+
+			if (g_NetworkInit)
+			{
+				g_NetworkInit(true, &data[0]);
+			}
 		}
 	}
 
@@ -121,7 +125,10 @@ void CConnectionManager::Init(puchar gameSeed)
 
 	m_IsLoginSocket = false;
 
-	g_NetworkInit(false, &gameSeed[0]);
+	if (g_NetworkInit)
+	{
+		g_NetworkInit(false, &gameSeed[0]);
+	}
 }
 //----------------------------------------------------------------------------------
 void CConnectionManager::SendIP(CSocket &socket, puchar seed)
@@ -339,22 +346,34 @@ int CConnectionManager::Send(puchar buf, int size)
 		if (!m_LoginSocket.Connected)
 			return 0; //Нет подключения
 
-		UCHAR_LIST cbuf(size); //Буффер для криптованного пакета
+		if (g_NetworkAction)
+		{
+			UCHAR_LIST cbuf(size); //Буффер для криптованного пакета
 
-		g_NetworkAction(true, &buf[0], &cbuf[0], size);
-
-		return m_LoginSocket.Send(cbuf); //Отправляем зашифрованный пакет
+			g_NetworkAction(true, &buf[0], &cbuf[0], size);
+			return m_LoginSocket.Send(cbuf); //Отправляем зашифрованный пакет
+		}
+		else
+		{
+			return m_LoginSocket.Send(buf, size);
+		}
 	}
 	else
 	{
 		if (!m_GameSocket.Connected)
 			return 0; //Нет подключения
 
-		UCHAR_LIST cbuf(size); //Буффер для криптованного пакета
+		if (g_NetworkAction)
+		{
+			UCHAR_LIST cbuf(size); //Буффер для криптованного пакета
 
-		g_NetworkAction(false, &buf[0], &cbuf[0], size);
-
-		return m_GameSocket.Send(cbuf); //Отправляем зашифрованный пакет
+			g_NetworkAction(false, &buf[0], &cbuf[0], size);
+			return m_GameSocket.Send(cbuf); //Отправляем зашифрованный пакет
+		}
+		else
+		{
+			return m_GameSocket.Send(buf, size);
+		}
 	}
 
 	return 0;

--- a/OrionUO/Managers/FileManager.cpp
+++ b/OrionUO/Managers/FileManager.cpp
@@ -24,121 +24,121 @@ bool CFileManager::Load()
 	//Try to use map uop files first, if we can, we will use them.
 	if (g_PacketManager.ClientVersion < CV_7000)
 	{
-		if (!m_ArtIdx.Load(g_App.FilePath("artidx.mul"))) return false;
-		if (!m_ArtMul.Load(g_App.FilePath("art.mul"))) return false;
-		if (!m_GumpIdx.Load(g_App.FilePath("gumpidx.mul"))) return false;
-		if (!m_GumpMul.Load(g_App.FilePath("gumpart.mul"))) return false;
-		if (!m_SoundIdx.Load(g_App.FilePath("soundidx.mul"))) return false;
-		if (!m_SoundMul.Load(g_App.FilePath("sound.mul"))) return false;
+		if (!m_ArtIdx.Load(g_Orion.ClientFilePath("artidx.mul"))) return false;
+		if (!m_ArtMul.Load(g_Orion.ClientFilePath("art.mul"))) return false;
+		if (!m_GumpIdx.Load(g_Orion.ClientFilePath("gumpidx.mul"))) return false;
+		if (!m_GumpMul.Load(g_Orion.ClientFilePath("gumpart.mul"))) return false;
+		if (!m_SoundIdx.Load(g_Orion.ClientFilePath("soundidx.mul"))) return false;
+		if (!m_SoundMul.Load(g_Orion.ClientFilePath("sound.mul"))) return false;
 	}
 	else
 	{
-		if (!m_artLegacyMUL.Load(g_App.FilePath("artLegacyMUL.uop")))
+		if (!m_artLegacyMUL.Load(g_Orion.ClientFilePath("artLegacyMUL.uop")))
 		{
-			if (!m_ArtIdx.Load(g_App.FilePath("artidx.mul"))) return false;
-			if (!m_ArtMul.Load(g_App.FilePath("art.mul"))) return false;
+			if (!m_ArtIdx.Load(g_Orion.ClientFilePath("artidx.mul"))) return false;
+			if (!m_ArtMul.Load(g_Orion.ClientFilePath("art.mul"))) return false;
 		}
 
-		if (!m_gumpartLegacyMUL.Load(g_App.FilePath("gumpartLegacyMUL.uop")))
+		if (!m_gumpartLegacyMUL.Load(g_Orion.ClientFilePath("gumpartLegacyMUL.uop")))
 		{
-			if (!m_GumpIdx.Load(g_App.FilePath("gumpidx.mul"))) return false;
-			if (!m_GumpMul.Load(g_App.FilePath("gumpart.mul"))) return false;
+			if (!m_GumpIdx.Load(g_Orion.ClientFilePath("gumpidx.mul"))) return false;
+			if (!m_GumpMul.Load(g_Orion.ClientFilePath("gumpart.mul"))) return false;
 			UseUOPGumps = false;
 		}
 		else
 			UseUOPGumps = true;
-		if (!m_soundLegacyMUL.Load(g_App.FilePath("soundLegacyMUL.uop")))
+		if (!m_soundLegacyMUL.Load(g_Orion.ClientFilePath("soundLegacyMUL.uop")))
 		{
-			if (!m_SoundIdx.Load(g_App.FilePath("soundidx.mul"))) return false;
-			if (!m_SoundMul.Load(g_App.FilePath("sound.mul"))) return false;
+			if (!m_SoundIdx.Load(g_Orion.ClientFilePath("soundidx.mul"))) return false;
+			if (!m_SoundMul.Load(g_Orion.ClientFilePath("sound.mul"))) return false;
 		}
 	}
 
 
 	/* Эти файлы не используются самой последней версией клиента 7.0.52.2
-	if (!m_tileart.Load(g_App.FilePath("tileart.uop")))
+	if (!m_tileart.Load(g_Orion.ClientFilePath("tileart.uop")))
 	return false;
-	if (!m_string_dictionary.Load(g_App.FilePath("string_dictionary.uop")))
+	if (!m_string_dictionary.Load(g_Orion.ClientFilePath("string_dictionary.uop")))
 	return false;
-	if (!m_MultiCollection.Load(g_App.FilePath("MultiCollection.uop")))
+	if (!m_MultiCollection.Load(g_Orion.ClientFilePath("MultiCollection.uop")))
 	return false;
-	if (!m_AnimationSequence.Load(g_App.FilePath("AnimationSequence.uop")))
+	if (!m_AnimationSequence.Load(g_Orion.ClientFilePathh("AnimationSequence.uop")))
 	return false;
-	if (!m_MainMisc.Load(g_App.FilePath("MainMisc.uop")))
+	if (!m_MainMisc.Load(g_Orion.ClientFilePath("MainMisc.uop")))
 	return false;
 	IFOR(i, 1, 5)
 	{
-	if (!m_AnimationFrame[i].Load(g_App.FilePath("AnimationFrame%i.uop", i)))
+	if (!m_AnimationFrame[i].Load(g_Orion.ClientFilePath("AnimationFrame%i.uop", i)))
 	return false;
 	}*/
 
-	if (!m_AnimIdx[0].Load(g_App.FilePath("anim.idx")))
+	if (!m_AnimIdx[0].Load(g_Orion.ClientFilePath("anim.idx")))
 		return false;
-	if (!m_LightIdx.Load(g_App.FilePath("lightidx.mul")))
+	if (!m_LightIdx.Load(g_Orion.ClientFilePath("lightidx.mul")))
 		return false;
-	else if (!m_MultiIdx.Load(g_App.FilePath("multi.idx")))
+	else if (!m_MultiIdx.Load(g_Orion.ClientFilePath("multi.idx")))
 		return false;
-	else if (!m_SkillsIdx.Load(g_App.FilePath("skills.idx")))
+	else if (!m_SkillsIdx.Load(g_Orion.ClientFilePath("skills.idx")))
 		return false;
-	else if (!m_MultiMap.Load(g_App.FilePath("multimap.rle")))
+	else if (!m_MultiMap.Load(g_Orion.ClientFilePath("multimap.rle")))
 		return false;
-	else if (!m_TextureIdx.Load(g_App.FilePath("texidx.mul")))
+	else if (!m_TextureIdx.Load(g_Orion.ClientFilePath("texidx.mul")))
 		return false;
-	else if (!m_AnimMul[0].Load(g_App.FilePath("anim.mul")))
+	else if (!m_AnimMul[0].Load(g_Orion.ClientFilePath("anim.mul")))
 		return false;
-	else if (!m_AnimdataMul.Load(g_App.FilePath("animdata.mul")))
+	else if (!m_AnimdataMul.Load(g_Orion.ClientFilePath("animdata.mul")))
 		return false;
-	else if (!m_HuesMul.Load(g_App.FilePath("hues.mul")))
+	else if (!m_HuesMul.Load(g_Orion.ClientFilePath("hues.mul")))
 		return false;
-	else if (!m_FontsMul.Load(g_App.FilePath("fonts.mul")))
+	else if (!m_FontsMul.Load(g_Orion.ClientFilePath("fonts.mul")))
 		return false;
-	else if (!m_LightMul.Load(g_App.FilePath("light.mul")))
+	else if (!m_LightMul.Load(g_Orion.ClientFilePath("light.mul")))
 		return false;
-	else if (!m_MultiMul.Load(g_App.FilePath("multi.mul")))
+	else if (!m_MultiMul.Load(g_Orion.ClientFilePath("multi.mul")))
 		return false;
-	else if (!m_PaletteMul.Load(g_App.FilePath("palette.mul")))
+	else if (!m_PaletteMul.Load(g_Orion.ClientFilePath("palette.mul")))
 		return false;
-	else if (!m_RadarcolMul.Load(g_App.FilePath("radarcol.mul")))
+	else if (!m_RadarcolMul.Load(g_Orion.ClientFilePath("radarcol.mul")))
 		return false;
-	else if (!m_SkillsMul.Load(g_App.FilePath("skills.mul")))
+	else if (!m_SkillsMul.Load(g_Orion.ClientFilePath("skills.mul")))
 		return false;
-	else if (!m_TextureMul.Load(g_App.FilePath("texmaps.mul")))
+	else if (!m_TextureMul.Load(g_Orion.ClientFilePath("texmaps.mul")))
 		return false;
-	else if (!m_TiledataMul.Load(g_App.FilePath("tiledata.mul")))
+	else if (!m_TiledataMul.Load(g_Orion.ClientFilePath("tiledata.mul")))
 		return false;
-	m_SpeechMul.Load(g_App.FilePath("speech.mul"));
-	m_LangcodeIff.Load(g_App.FilePath("Langcode.iff"));
+	m_SpeechMul.Load(g_Orion.ClientFilePath("speech.mul"));
+	m_LangcodeIff.Load(g_Orion.ClientFilePath("Langcode.iff"));
 
 	IFOR(i, 0, 6)
 	{
 		if (i > 0)
 		{
-			m_AnimIdx[i].Load(g_App.FilePath("anim%i.idx", i));
-			m_AnimMul[i].Load(g_App.FilePath("anim%i.mul", i));
+			m_AnimIdx[i].Load(g_Orion.ClientFilePath("anim%i.idx", i));
+			m_AnimMul[i].Load(g_Orion.ClientFilePath("anim%i.mul", i));
 		}
 		if (g_PacketManager.ClientVersion < CV_7000)
 		{
-			m_MapMul[i].Load(g_App.FilePath("map%i.mul", i));
+			m_MapMul[i].Load(g_Orion.ClientFilePath("map%i.mul", i));
 		}
 		else
 		{
-			if (m_MapUOP[i].Load(g_App.FilePath("map%iLegacyMUL.uop", i)))
+			if (m_MapUOP[i].Load(g_Orion.ClientFilePath("map%iLegacyMUL.uop", i)))
 				UseUOPMap = true;
 			else
-				m_MapMul[i].Load(g_App.FilePath("map%i.mul", i));
+				m_MapMul[i].Load(g_Orion.ClientFilePath("map%i.mul", i));
 		}
 
 
-		m_StaticIdx[i].Load(g_App.FilePath("staidx%i.mul", i));
-		m_StaticMul[i].Load(g_App.FilePath("statics%i.mul", i));
-		m_FacetMul[i].Load(g_App.FilePath("facet0%i.mul", i));
+		m_StaticIdx[i].Load(g_Orion.ClientFilePath("staidx%i.mul", i));
+		m_StaticMul[i].Load(g_Orion.ClientFilePath("statics%i.mul", i));
+		m_FacetMul[i].Load(g_Orion.ClientFilePath("facet0%i.mul", i));
 
-		m_MapDifl[i].Load(g_App.FilePath("mapdifl%i.mul", i));
-		m_MapDif[i].Load(g_App.FilePath("mapdif%i.mul", i));
+		m_MapDifl[i].Load(g_Orion.ClientFilePath("mapdifl%i.mul", i));
+		m_MapDif[i].Load(g_Orion.ClientFilePath("mapdif%i.mul", i));
 
-		m_StaDifl[i].Load(g_App.FilePath("stadifl%i.mul", i));
-		m_StaDifi[i].Load(g_App.FilePath("stadifi%i.mul", i));
-		m_StaDif[i].Load(g_App.FilePath("stadif%i.mul", i));
+		m_StaDifl[i].Load(g_Orion.ClientFilePath("stadifl%i.mul", i));
+		m_StaDifi[i].Load(g_Orion.ClientFilePath("stadifi%i.mul", i));
+		m_StaDif[i].Load(g_Orion.ClientFilePath("stadif%i.mul", i));
 	}
 
 	IFOR(i, 0, 20)
@@ -146,9 +146,9 @@ bool CFileManager::Load()
 		string s;
 		
 		if (i)
-			s = g_App.FilePath("unifont%i.mul", i);
+			s = g_Orion.ClientFilePath("unifont%i.mul", i);
 		else
-			s = g_App.FilePath("unifont.mul");
+			s = g_Orion.ClientFilePath("unifont.mul");
 
 		if (!m_UnifontMul[i].Load(s) && i > 1)
 			break;
@@ -156,7 +156,7 @@ bool CFileManager::Load()
 		m_UnicodeFontsCount++;
 	}
 
-	if (m_UseVerdata && !m_VerdataMul.Load(g_App.FilePath("verdata.mul")))
+	if (m_UseVerdata && !m_VerdataMul.Load(g_Orion.ClientFilePath("verdata.mul")))
 		m_UseVerdata = false;
 
 	return true;
@@ -249,7 +249,7 @@ void CFileManager::ReadTask()
 		char nextBlock[8];
 
 		std::fstream *animFile = new std::fstream();
-		string *path = new string(g_App.FilePath("AnimationFrame%i.uop", i));
+		string *path = new string(g_Orion.ClientFilePath("AnimationFrame%i.uop", i));
 		if (!FileExists(*path))
 		{
 			continue;

--- a/OrionUO/Managers/PacketManager.cpp
+++ b/OrionUO/Managers/PacketManager.cpp
@@ -313,7 +313,7 @@ bool CPacketManager::AutoLoginNameExists(const string &name)
 	#define CVPRINT(s)
 #endif //CV_PRINT!=0
 //----------------------------------------------------------------------------------
-void CPacketManager::OnClientVersionChange(const CLIENT_VERSION &newClientVersion)
+void CPacketManager::OnClientVersionChange(const uint32_t &newClientVersion)
 {
 	WISPFUN_DEBUG("c150_f2");
 	if (newClientVersion >= CV_500A)

--- a/OrionUO/Managers/PacketManager.h
+++ b/OrionUO/Managers/PacketManager.h
@@ -68,7 +68,7 @@ struct HTMLGumpDataInfo
 //----------------------------------------------------------------------------------
 class CPacketManager : public WISP_NETWORK::CPacketReader
 {
-	SETGETE(CLIENT_VERSION, ClientVersion, CV_OLD, OnClientVersionChange);
+	SETGETE(uint32_t, ClientVersion, CV_OLD, OnClientVersionChange);
 	SETGET(string, AutoLoginNames, "");
 	SETGET(uint, LastGumpID, 0);
 	SETGET(uint, LastGumpX, 0);

--- a/OrionUO/Managers/ProfessionManager.cpp
+++ b/OrionUO/Managers/ProfessionManager.cpp
@@ -324,7 +324,7 @@ bool CProfessionManager::Load()
 	head->TopLevel = true;
 	Add(head);
 
-	WISP_FILE::CTextFileParser file(g_App.FilePath("prof.txt"), " \t,", "#;", "\"\"");
+	WISP_FILE::CTextFileParser file(g_Orion.ClientFilePath("prof.txt"), " \t,", "#;", "\"\"");
 
 	if (!file.IsEOF())
 	{
@@ -401,7 +401,7 @@ void CProfessionManager::LoadProfessionDescription()
 	WISPFUN_DEBUG("c153_f5");
 	WISP_FILE::CMappedFile file;
 
-	if (file.Load(g_App.FilePath("professn.enu")))
+	if (file.Load(g_Orion.ClientFilePath("professn.enu")))
 	{
 		char *ptr = (char*)file.Start;
 		char *end = (char*)((uint)file.Start + file.Size);

--- a/OrionUO/Network/Connection.cpp
+++ b/OrionUO/Network/Connection.cpp
@@ -180,7 +180,9 @@ UCHAR_LIST CSocket::Decompression(UCHAR_LIST data)
 		int inSize = data.size();
 
 		if (g_NetworkPostAction != NULL)
+		{
 			g_NetworkPostAction(&data[0], &data[0], inSize);
+		}
 
 		UCHAR_LIST decBuf(inSize * 4 + 2);
 

--- a/OrionUO/OrionUO.cpp
+++ b/OrionUO/OrionUO.cpp
@@ -957,6 +957,14 @@ void COrion::LoadClientConfig()
 		{
 			ClientVersionText = strings[1];
 			g_PacketManager.ClientVersion = ParseVersion(strings[1]);
+			if (g_PacketManager.ClientVersion < CV_4011D)
+			{
+				/* On this client, Felucca and Trammel were narrower */
+				g_MapSize[0].Width = 6144;
+				g_MapSize[1].Width = 6144;
+				g_MapBlockSize[0].Width = 768;
+				g_MapBlockSize[0].Width = 768;
+			}
 		}
 		else if (strings[0] == "UseVerdata")
 		{
@@ -1028,11 +1036,8 @@ void COrion::LoadClientConfig()
 
 		IFOR(i, 0, MAX_MAPS_COUNT)
 		{
-			g_MapSize[i].Width = file.ReadUInt16LE();
-			g_MapSize[i].Height = file.ReadUInt16LE();
-
-			g_MapBlockSize[i].Width = g_MapSize[i].Width / 8;
-			g_MapBlockSize[i].Height = g_MapSize[i].Height / 8;
+			file.ReadUInt16LE();
+			file.ReadUInt16LE();
 		}
 
 		g_CharacterList.ClientFlag = file.ReadInt8();

--- a/OrionUO/OrionUO.cpp
+++ b/OrionUO/OrionUO.cpp
@@ -848,6 +848,23 @@ void COrion::CheckStaticTileFilterFiles()
 	}
 }
 //----------------------------------------------------------------------------------
+string COrion::ClientFilePath(const char *fname, ...)
+{
+	WISPFUN_DEBUG("c1_f4");
+	va_list arg;
+	va_start(arg, fname);
+
+	if (ClientPath.length() == 0) {
+		return g_App.FilePath(fname);
+	}
+
+	char out[MAX_PATH] = { 0 };
+	vsprintf_s(out, MAX_PATH, fname, arg);
+	va_end(arg);
+
+	return ClientPath + "\\" + out;
+}
+//----------------------------------------------------------------------------------
 void COrion::LoadClientConfig()
 {
 	WISPFUN_DEBUG("c194_f11");
@@ -869,6 +886,21 @@ void COrion::LoadClientConfig()
 			if (strings.size() >= 3)
 			{
 				LoginPort = std::stoi(strings[2]);
+			}
+		}
+		else if (strings[0] == "ClientPath")
+		{
+			char fullPath[MAX_PATH] = {};
+
+			if (GetFullPathNameA(strings[1].c_str(), sizeof(fullPath), fullPath, NULL) > 0)
+			{
+				ClientPath = fullPath;
+			}
+			else
+			{
+				g_OrionWindow.ShowMessage("ClientPath not specified in client.cfg!", "Error!");
+				ExitProcess(0);
+				return;
 			}
 		}
 	}
@@ -2884,7 +2916,7 @@ void COrion::LoadLogin(string &login, int &port)
 	WISPFUN_DEBUG("c194_f45");
 	if (m_LoginPort == 0)
 	{
-		WISP_FILE::CTextFileParser file(g_App.FilePath("login.cfg"), "=,", "#;", "");
+		WISP_FILE::CTextFileParser file(g_Orion.ClientFilePath("login.cfg"), "=,", "#;", "");
 
 		while (!file.IsEOF())
 		{
@@ -3662,12 +3694,12 @@ void COrion::IndexReplaces()
 {
 	WISPFUN_DEBUG("c194_f55");
 	WISP_FILE::CTextFileParser newDataParser("", " \t,{}", "#;//", "");
-	WISP_FILE::CTextFileParser artParser(g_App.FilePath("Art.def"), " \t", "#;//", "{}");
-	WISP_FILE::CTextFileParser textureParser(g_App.FilePath("TexTerr.def"), " \t", "#;//", "{}");
-	WISP_FILE::CTextFileParser gumpParser(g_App.FilePath("Gump.def"), " \t", "#;//", "{}");
-	WISP_FILE::CTextFileParser multiParser(g_App.FilePath("Multi.def"), " \t", "#;//", "{}");
-	WISP_FILE::CTextFileParser soundParser(g_App.FilePath("Sound.def"), " \t", "#;//", "{}");
-	WISP_FILE::CTextFileParser mp3Parser(g_App.FilePath("Music\\Digital\\Config.txt"), " ,", "#;", "");
+	WISP_FILE::CTextFileParser artParser(g_Orion.ClientFilePath("Art.def"), " \t", "#;//", "{}");
+	WISP_FILE::CTextFileParser textureParser(g_Orion.ClientFilePath("TexTerr.def"), " \t", "#;//", "{}");
+	WISP_FILE::CTextFileParser gumpParser(g_Orion.ClientFilePath("Gump.def"), " \t", "#;//", "{}");
+	WISP_FILE::CTextFileParser multiParser(g_Orion.ClientFilePath("Multi.def"), " \t", "#;//", "{}");
+	WISP_FILE::CTextFileParser soundParser(g_Orion.ClientFilePath("Sound.def"), " \t", "#;//", "{}");
+	WISP_FILE::CTextFileParser mp3Parser(g_Orion.ClientFilePath("Music\\Digital\\Config.txt"), " ,", "#;", "");
 
 	if (g_PacketManager.ClientVersion < CV_305D) //CV_204C
 		return;
@@ -3888,7 +3920,7 @@ void COrion::IndexReplaces()
 			if (name.find(extension) == string::npos)
 				name += extension;
 				if (size > 1)
-				mp3.FilePath = g_App.FilePath((name).c_str());
+				mp3.FilePath = g_Orion.ClientFilePath((name).c_str());
 
 				if (size > 2)
 					mp3.Loop = true;

--- a/OrionUO/OrionUO.cpp
+++ b/OrionUO/OrionUO.cpp
@@ -103,8 +103,8 @@ void COrion::ParseCommandLine()
 		{
 			if (str == "login")
 			{
-				m_DefaultLogin = strings[1];
-				m_DefaultPort = atoi(strings[2].c_str());
+				LoginServer = strings[1];
+				LoginPort = atoi(strings[2].c_str());
 			}
 			else if (str == "proxyhost")
 			{
@@ -851,6 +851,28 @@ void COrion::CheckStaticTileFilterFiles()
 void COrion::LoadClientConfig()
 {
 	WISPFUN_DEBUG("c194_f11");
+	WISP_FILE::CTextFileParser file(g_App.FilePath("client.cfg"), "=,", "#;", "");
+
+	while (!file.IsEOF())
+	{
+		std::vector<std::string> strings = file.ReadTokens();
+
+		if (strings.size() < 2)
+		{
+			continue;
+		}
+
+		if (strings[0] == "LoginServer")
+		{
+			LoginServer = strings[1];
+
+			if (strings.size() >= 3)
+			{
+				LoginPort = std::stoi(strings[2]);
+			}
+		}
+	}
+
 	HMODULE orionDll = LoadLibrary(g_App.FilePath(L"Orion.dll").c_str());
 
 	if (orionDll == 0)
@@ -2860,31 +2882,29 @@ bool COrion::IsVegetation(const ushort &graphic)
 void COrion::LoadLogin(string &login, int &port)
 {
 	WISPFUN_DEBUG("c194_f45");
-	if (m_DefaultPort)
+	if (m_LoginPort == 0)
 	{
-		login = m_DefaultLogin;
-		port = m_DefaultPort;
+		WISP_FILE::CTextFileParser file(g_App.FilePath("login.cfg"), "=,", "#;", "");
 
-		return;
-	}
-
-	WISP_FILE::CTextFileParser file(g_App.FilePath("login.cfg"), "=,", "#;", "");
-
-	while (!file.IsEOF())
-	{
-		STRING_LIST strings = file.ReadTokens();
-
-		if (strings.size() >= 3)
+		while (!file.IsEOF())
 		{
-			string lo = ToLowerA(strings[0]);
+			STRING_LIST strings = file.ReadTokens();
 
-			if (lo == "loginserver")
+			if (strings.size() >= 3)
 			{
-				login = strings[1];
-				port = atoi(strings[2].c_str());
+				string lo = ToLowerA(strings[0]);
+
+				if (lo == "loginserver")
+				{
+					LoginServer = strings[1];
+					LoginPort = atoi(strings[2].c_str());
+				}
 			}
 		}
 	}
+
+	login = m_LoginServer;
+	port = m_LoginPort;
 }
 //----------------------------------------------------------------------------------
 void COrion::GoToWebLink(const string &url)

--- a/OrionUO/OrionUO.h
+++ b/OrionUO/OrionUO.h
@@ -14,8 +14,8 @@ class COrion
 {
 	SETGET(string, ClientVersionText, "2.0.3");
 	SETGET(int, TexturesDataCount, 0);
-	SETGET(string, DefaultLogin, "");
-	SETGET(int, DefaultPort, 0);
+	SETGET(string, LoginServer, "");
+	SETGET(int, LoginPort, 0);
 
 private:
 	uint m_CRC_Table[256];

--- a/OrionUO/OrionUO.h
+++ b/OrionUO/OrionUO.h
@@ -12,11 +12,11 @@
 //----------------------------------------------------------------------------------
 class COrion
 {
-	SETGET(string, ClientVersionText, "2.0.3");
 	SETGET(int, TexturesDataCount, 0);
 	SETGET(string, LoginServer, "");
 	SETGET(int, LoginPort, 0);
 	SETGET(string, ClientPath, "");
+	SETGET(string, ClientVersionText, "5.0.8.3");
 
 private:
 	uint m_CRC_Table[256];
@@ -36,6 +36,8 @@ private:
 	deque<CIndexObject*> m_UsedLightList;
 
 	UCHAR_LIST m_AnimData;
+
+	uint32_t ParseVersion(std::string& version);
 
 	void LoadClientConfig();
 	void LoadAutoLoginNames();

--- a/OrionUO/OrionUO.h
+++ b/OrionUO/OrionUO.h
@@ -16,6 +16,7 @@ class COrion
 	SETGET(int, TexturesDataCount, 0);
 	SETGET(string, LoginServer, "");
 	SETGET(int, LoginPort, 0);
+	SETGET(string, ClientPath, "");
 
 private:
 	uint m_CRC_Table[256];
@@ -142,7 +143,7 @@ public:
 
 	static string FixServerName(string name);
 
-
+	string ClientFilePath(const char *fname, ...);
 	
 	//Подключиться к логин сокету
 	void Connect();

--- a/OrionUO/PluginInterface.h
+++ b/OrionUO/PluginInterface.h
@@ -53,7 +53,7 @@ typedef struct PLUGIN_INTERFACE
 	struct PLUGIN_CLIENT_INTERFACE *Client;
 
 	HWND hWnd;
-	CLIENT_VERSION ClientVersion;
+	uint32_t ClientVersion;
 	bool UseVerdata;
 
 	PACKET_PROC *Recv;


### PR DESCRIPTION
Add a configuration file, client.cfg, that contains the login server, the location of the client, and the client version. Then, make Orion.dll and client.cuo optional. If the user wants to leverage the plugin system (i.e. OrionAssist), they'll need Orion.dll and client.cuo. If they don't, then they just need to fill out client.cfg and don't even need to run ConfigurationEditor.exe or OrionLauncher.exe at all.

This is also convenient because the user can point OrionUO at the client instead of copying the OrionUO files to a client installation directory.