### PR TITLE
Always automatically open doors the player attempts to run through

### DIFF
--- a/OrionUO/Walker/PathFinder.cpp
+++ b/OrionUO/Walker/PathFinder.cpp
@@ -105,6 +105,8 @@ bool CPathFinder::CreateItemsList(vector<CPathObject> &list, const int &x, const
 					canBeAdd = false;
 				else if (stepState == PSS_DEAD_OR_GM && (go->IsDoor() || tileInfo->Weight <= 0x5A || (isGM && !go->Locked())))
 					dropFlags = true;
+				else if (go->IsDoor())
+					g_Orion.OpenDoor();
 				else
 					dropFlags = ((graphic >= 0x3946 && graphic <= 0x3964) || graphic == 0x0082);
 			}


### PR DESCRIPTION
No one plays the game without an assistant that automatically opens doors, so just make it part of the base functionality of the client.