### PR TITLE
Fix 0xBF Packet Handler Bug

### DIFF
--- a/OrionUO/Managers/PacketManager.cpp
+++ b/OrionUO/Managers/PacketManager.cpp
@@ -2256,7 +2256,7 @@ PACKET_HANDLER(ExtendedCommand)
 				crafterNameLen = ReadUInt16BE();
 				if (crafterNameLen)
 				{
-					wstring crafterName = ReadWString(crafterNameLen);
+					wstring crafterName = ToWString(ReadString(crafterNameLen));
 					str = L"Crafted by ";
 					str += crafterName;
 				}


### PR DESCRIPTION
0xBF Packet Handler is reading sub command 0x10 Crafter Names as ReadWString, causing a display bug. 
![snapshot_d 2017 9 9 _t 14 34 43_295](https://user-images.githubusercontent.com/2975764/30341708-e62fc9f8-97ab-11e7-8585-395dbfb9afe0.png)
